### PR TITLE
RFC: Entrypoint-based config transforms

### DIFF
--- a/image/src/dev-transforms/CustomErrors/Web.config.xdt
+++ b/image/src/dev-transforms/CustomErrors/Web.config.xdt
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <system.web>
+    <customErrors mode="Off"
+                  xdt:Transform="SetAttributes" />
+  </system.web>
+</configuration>

--- a/image/src/dev-transforms/Debug/Web.config.xdt
+++ b/image/src/dev-transforms/Debug/Web.config.xdt
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <system.web>
+    <compilation debug="true"
+                 xdt:Transform="SetAttributes" />
+  </system.web>
+</configuration>

--- a/image/src/dev-transforms/OptimizeCompilations/Web.config.xdt
+++ b/image/src/dev-transforms/OptimizeCompilations/Web.config.xdt
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <system.web>
+    <compilation optimizeCompilations="true"
+                 xdt:Transform="SetAttributes" />
+  </system.web>
+</configuration>

--- a/image/src/entrypoints/iis/Development.ps1
+++ b/image/src/entrypoints/iis/Development.ps1
@@ -48,6 +48,22 @@ else
     Write-Host "$(Get-Date -Format $timeFormat): Development ENTRYPOINT: Skipping start of '$watchDirectoryJobName'. To enable you should mount a directory into 'C:\deploy'."
 }
 
+
+# RFC: Apply development Web.config transforms on startup
+# TODO: Clean up and make testable
+# Example: SITECORE_DEVELOPMENT_TRANSFORMS=CustomErrors,Debug,OptimizeCompilations
+$transforms = $env:SITECORE_DEVELOPMENT_TRANSFORMS
+if ($transforms) {
+    $env:SITECORE_DEVELOPMENT_TRANSFORMS.Split(",|") | ForEach-Object {
+        $folder = "..\..\dev-transforms\$_"
+        if (-not (Test-Path $folder)) {
+            Write-Host "** Sitecore Development Transform $_ not found"
+        } else {
+            ..\..\scripts\Invoke-XdtTransform.ps1 -XdtPath $folder -Path $WatchDirectoryParameters.Destination
+        }
+    }
+}
+
 # Print ready message
 Write-Host "$(Get-Date -Format $timeFormat): Development ENTRYPOINT: ready!"
 


### PR DESCRIPTION
**RFC: DO NOT MERGE**

## Concept
Allow configuration of development-specific Web.config transforms in the development entrypoint. Docker Tools would provide some of the essentials, but developers could add others.

### Example
```
SITECORE_DEVELOPMENT_TRANSFORMS=CustomErrors,Debug,OptimizeCompilations
```

## Why not do this in my Dockerfile?
It allows you to have a consistent image build for dev, test, and prod.

## Is there some way to set these values purely with environment variables and `configBuilders`?
My POC with [Section Handlers](https://github.com/aspnet/MicrosoftConfigurationBuilders#section-handlers) was only half-successful. It's possible for `customErrors` but not `compilation`, due to availability of the app domain during configuration load.

## Why an environment variable and not a entrypoint script argument?
Seems cleaner this way, but open to input on this.