### PR TITLE
Implementation of cross-platform support

### DIFF
--- a/powershell/src/Public/Get-SitecoreCertificateAsBase64String.ps1
+++ b/powershell/src/Public/Get-SitecoreCertificateAsBase64String.ps1
@@ -28,36 +28,19 @@ function Get-SitecoreCertificateAsBase64String
         $DnsName = "localhost"
     )
 
-    # Create the certificate
-    $params = @{
-        DnsName = $DnsName
-        NotAfter = (Get-Date).AddYears(5)
-    }
-    $cert = New-SelfSignedCertificate @params
+    $certRequest = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
+        [X500DistinguishedName]::new("CN=$DnsName"), 
+        [System.Security.Cryptography.RSA]::Create(), 
+        [System.Security.Cryptography.HashAlgorithmName]::SHA256, 
+        [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
 
-    Write-Verbose "Created temporary self-signed certificate $($cert.Thumbprint) for $DnsName"
+    $basicConstraints = [System.Security.Cryptography.X509Certificates.X509BasicConstraintsExtension]::new($false, $false, 0, $false)
+    $certRequest.CertificateExtensions.Add($basicConstraints)
+    $subjectKeyIdentifier = [System.Security.Cryptography.X509Certificates.X509SubjectKeyIdentifierExtension]::new($certRequest.PublicKey, $false)
+    $certRequest.CertificateExtensions.Add($subjectKeyIdentifier)
 
-    # Export to pfx
-    $pfxPath = Join-Path $Env:TEMP "sitecorecertificate.pfx"
-    $params = @{
-        Cert = $cert
-        FilePath = $pfxPath
-        Password = $Password
-        Force = $true
-    }
-    Export-PfxCertificate @params | Out-Null
-
-    Write-Verbose "Exported certificate to temporary pfx file $pfxPath"
-
-    # Get Base64 encoded form of the pfx
-    $encodedString = [System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes((Get-Item $pfxPath)))
-
-    # Cleanup
-    $cert | Remove-Item
-    $pfxPath | Remove-Item
-
-    Write-Verbose "Temporary certificate and pfx file removed"
-
-    # Return Base64 encoded string
-    return $encodedString
+    $certificate = $certRequest.CreateSelfSigned([datetime]::Now, [datetime]::Now.AddYears(5))
+    $certificateBytes = $certificate.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Pfx, $Password)
+    
+    return [System.Convert]::ToBase64String($certificateBytes)
 }

--- a/powershell/test/Public/Add-HostsEntry.Tests.ps1
+++ b/powershell/test/Public/Add-HostsEntry.Tests.ps1
@@ -68,7 +68,7 @@
 
                 Assert-MockCalled Get-Content -Times 1 -Exactly -ParameterFilter {
                     $Path -eq $hostsPath -and `
-                    $Encoding -eq 'UTF8'
+                    ($Encoding.ToString() -eq "System.Text.UTF8Encoding" -or $Encoding.ToString() -eq "UTF8")
                 } -Scope It
             }
 
@@ -77,7 +77,7 @@
 
                 Assert-MockCalled WriteLines -Times 1 -Exactly -ParameterFilter {
                     $File -eq $hostsPath -and `
-                    $Encoding -eq [System.Text.Encoding]::UTF8
+                    ($Encoding.ToString() -eq "System.Text.UTF8Encoding+UTF8EncodingSealed" -or $Encoding.ToString() -eq "System.Text.UTF8Encoding")
                 } -Scope It
             }
         }

--- a/powershell/test/Public/Remove-HostsEntry.Tests.ps1
+++ b/powershell/test/Public/Remove-HostsEntry.Tests.ps1
@@ -65,7 +65,7 @@
 
                 Assert-MockCalled Get-Content -Times 1 -Exactly -ParameterFilter {
                     $Path -eq $hostsPath -and `
-                    $Encoding -eq 'UTF8'
+                    ($Encoding.ToString() -eq "System.Text.UTF8Encoding" -or $Encoding.ToString() -eq "UTF8")
                 } -Scope It
             }
 
@@ -74,7 +74,7 @@
 
                 Assert-MockCalled WriteLines -Times 1 -Exactly -ParameterFilter {
                     $File -eq $hostsPath -and `
-                    $Encoding -eq [System.Text.Encoding]::UTF8
+                    ($Encoding.ToString() -eq "System.Text.UTF8Encoding+UTF8EncodingSealed" -or $Encoding.ToString() -eq "System.Text.UTF8Encoding")
                 } -Scope It
             }
         }
@@ -82,7 +82,7 @@
         Context 'When the hosts file is empty' {
             Mock Get-Content {
                 return $null
-            } -ParameterFilter { $Path -eq $hostsPath -and $Encoding -eq "UTF8"}
+            } -ParameterFilter { $Path -eq $hostsPath -and ($Encoding.ToString() -eq "System.Text.UTF8Encoding" -or $Encoding.ToString() -eq "UTF8")}
 
             Mock WriteLines
 
@@ -98,7 +98,7 @@
         Context 'When the hosts file contains only comments' {
             Mock Get-Content {
                 return @("# Hosts file comment")
-            } -ParameterFilter { $Path -eq $hostsPath -and $Encoding -eq "UTF8"}
+            } -ParameterFilter { $Path -eq $hostsPath -and ($Encoding.ToString() -eq "System.Text.UTF8Encoding" -or $Encoding.ToString() -eq "UTF8")}
 
             Mock WriteLines
 
@@ -114,7 +114,7 @@
         Context 'When there are no matching host headers in the host file' {
             Mock Get-Content {
                 return @("10.10.10.10`thostName1", "20.20.20.20`thostName2", "30.30.30.30`thostName3")
-            } -ParameterFilter { $Path -eq $hostsPath -and $Encoding -eq "UTF8"}
+            } -ParameterFilter { $Path -eq $hostsPath -and ($Encoding.ToString() -eq "System.Text.UTF8Encoding" -or $Encoding.ToString() -eq "UTF8")}
 
             Mock WriteLines
 
@@ -130,7 +130,7 @@
         Context 'When there is single host header in the hosts file' {
             Mock Get-Content {
                 return @("10.10.10.10`thostName1")
-            } -ParameterFilter { $Path -eq $hostsPath -and $Encoding -eq "UTF8"}
+            } -ParameterFilter { $Path -eq $hostsPath -and ($Encoding.ToString() -eq "System.Text.UTF8Encoding" -or $Encoding.ToString() -eq "UTF8")}
 
             Mock WriteLines
 
@@ -141,7 +141,7 @@
                 Assert-MockCalled WriteLines -Times 1 -Exactly -ParameterFilter {
                     $File -eq $hostsPath -and `
                     $Content -eq $null -and `
-                    $Encoding -eq [System.Text.Encoding]::UTF8
+                    ($Encoding.ToString() -eq "System.Text.UTF8Encoding+UTF8EncodingSealed" -or $Encoding.ToString() -eq "System.Text.UTF8Encoding")
                 }
             }
         }
@@ -149,7 +149,7 @@
         Context 'When there are single host header and comment in the hosts file' {
             Mock Get-Content {
                 return @("# Hosts file comment", "10.10.10.10`thostName1")
-            } -ParameterFilter { $Path -eq $hostsPath -and $Encoding -eq "UTF8"}
+            } -ParameterFilter { $Path -eq $hostsPath -and ($Encoding.ToString() -eq "System.Text.UTF8Encoding" -or $Encoding.ToString() -eq "UTF8")}
 
             Mock WriteLines
 
@@ -159,7 +159,7 @@
                 Assert-MockCalled WriteLines -Times 1 -Exactly -ParameterFilter {
                     $File -eq $hostsPath -and `
                     @(Compare-Object -ReferenceObject @("# Hosts file comment") -DifferenceObject $Content).Count -eq 0 -and `
-                    $Encoding -eq [System.Text.Encoding]::UTF8
+                    ($Encoding.ToString() -eq "System.Text.UTF8Encoding+UTF8EncodingSealed" -or $Encoding.ToString() -eq "System.Text.UTF8Encoding")
                 }
             }
         }
@@ -167,7 +167,7 @@
         Context 'When there are multiple host headers in the hosts file' {
             Mock Get-Content {
                 return @("10.10.10.10`thostName1", "20.20.20.20`thostName2", "30.30.30.30`thostName3")
-            } -ParameterFilter { $Path -eq $hostsPath -and $Encoding -eq "UTF8"}
+            } -ParameterFilter { $Path -eq $hostsPath -and ($Encoding.ToString() -eq "System.Text.UTF8Encoding" -or $Encoding.ToString() -eq "UTF8")}
 
             Mock WriteLines
 
@@ -177,7 +177,7 @@
                 Assert-MockCalled WriteLines -Times 1 -Exactly -ParameterFilter {
                     $File -eq $hostsPath -and `
                     @(Compare-Object -ReferenceObject @("10.10.10.10`thostName1", "30.30.30.30`thostName3") -DifferenceObject $Content).Count -eq 0 -and `
-                    $Encoding -eq [System.Text.Encoding]::UTF8
+                    ($Encoding.ToString() -eq "System.Text.UTF8Encoding+UTF8EncodingSealed" -or $Encoding.ToString() -eq "System.Text.UTF8Encoding")
                 }
             }
         }

--- a/powershell/test/Public/Set-EnvFileVariable.Tests.ps1
+++ b/powershell/test/Public/Set-EnvFileVariable.Tests.ps1
@@ -34,7 +34,7 @@
         It 'adds variable on new line to end of file' {
             Set-Content $envFile -Value 'VAR1=VAL1'
             Set-EnvFileVariable -Path $envFile -Variable 'VAR2' -Value 'VAL2'
-            $envFile | Should -FileContentMatchMultiline '^VAR1=VAL1\r\nVAR2=VAL2\r\n$'
+            $envFile | Should -FileContentMatchMultiline '^VAR1=VAL1\r?\nVAR2=VAL2\r?\n$'
         }
 
         It 'sets existing variable with value to new value' {
@@ -143,7 +143,7 @@
 
                 Assert-MockCalled Get-Content -Times 1 -Exactly -ParameterFilter {
                     $Path -eq $envFile -and `
-                    $Encoding -eq 'UTF8'
+                    ($Encoding.ToString() -eq "System.Text.UTF8Encoding" -or $Encoding.ToString() -eq "UTF8")
                 } -Scope It
             }
 
@@ -152,7 +152,7 @@
 
                 Assert-MockCalled WriteLines -Times 1 -Exactly -ParameterFilter {
                     $File -eq $envFile -and `
-                    $Encoding -eq [System.Text.Encoding]::UTF8
+                    ($Encoding.ToString() -eq "System.Text.UTF8Encoding+UTF8EncodingSealed" -or $Encoding.ToString() -eq "System.Text.UTF8Encoding")
                 } -Scope It
             }
         }


### PR DESCRIPTION
Certificate creation is rewritten to use pure .net
Fixes for paths operations and newline checks in tests
Aligned breaking change in UTF8 behavior on classic powershell vs powershell core
Tests are green when run under linux/pwsh and windows/powershell