### PR TITLE
Updated key size for self signed certificate

### DIFF
--- a/powershell/src/Public/Get-SitecoreCertificateAsBase64String.ps1
+++ b/powershell/src/Public/Get-SitecoreCertificateAsBase64String.ps1
@@ -30,7 +30,7 @@ function Get-SitecoreCertificateAsBase64String
         [Parameter()]
         [ValidateSet(512, 1024, 2048, 4096)]
         [int]
-        $KeyLength = 1024
+        $KeyLength = 2048
     )
 
     $certRequest = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(


### PR DESCRIPTION
Due to September security patches from Microsoft the minimal valid RSA key size for certificate is 2048 bits. Updated the code to be aligned with latest security patch.