### PR TITLE
Updated scripts to work with the services (IndexWorker, AutomationEngine, ProcessingEngine)

### DIFF
--- a/image/src/entrypoints/worker/Development.ps1
+++ b/image/src/entrypoints/worker/Development.ps1
@@ -8,6 +8,7 @@ param(
 $ErrorActionPreference = "Stop"
 $InformationPreference = "Continue"
 $timeFormat = "HH:mm:ss:fff"
+$executable = "C:\\service\\$($env:WORKER_EXECUTABLE_NAME_ENV)"
 
 # Print start message
 Write-Host "$(Get-Date -Format $timeFormat): Development ENTRYPOINT: starting..."
@@ -23,32 +24,21 @@ if ($useWatchDirectory)
     {
         $WatchDirectoryParameters = @{ Path = "C:\deploy"; Destination = "C:\service"; }
     }
-
+    $WatchDirectoryParameters["Executable"] = $executable
     Write-Host "$(Get-Date -Format $timeFormat): Development ENTRYPOINT: '$watchDirectoryJobName' validating..."
 
     # First a trial-run to catch any parameter validation / setup errors
     $WatchDirectoryParameters["WhatIf"] = $true
     & "C:\tools\scripts\Watch-Directory.ps1" @WatchDirectoryParameters
     $WatchDirectoryParameters["WhatIf"] = $false
-    
-    Write-Host "$(Get-Date -Format $timeFormat): Development ENTRYPOINT: '$watchDirectoryJobName' starting..."
-
-    # Start Watch-Directory.ps1 in background
-    Start-Job -Name $watchDirectoryJobName -ArgumentList $WatchDirectoryParameters -ScriptBlock {
-        param([hashtable]$params)
-
-        & "C:\tools\scripts\Watch-Directory.ps1" @params
-
-    } | Out-Null
 
     Write-Host "$(Get-Date -Format $timeFormat): Development ENTRYPOINT: '$watchDirectoryJobName' started."
+
+    & "C:\tools\scripts\Watch-Directory.ps1" @WatchDirectoryParameters
 }
 else
 {
-    Write-Host ("$(Get-Date -Format $timeFormat): Development ENTRYPOINT: Skipping start of '$watchDirectoryJobName'. To enable you should mount a directory into 'C:\deploy'.")
+    Write-Host ("$(Get-Date -Format $timeFormat): Development ENTRYPOINT: Skipping start of '$watchDirectoryJobName'. To enable you should mount a directory into '$watchFolder'.")
+    Write-Host "$(Get-Date -Format $timeFormat): Development ENTRYPOINT: ready!"
+    & "$executable"
 }
-
-# Print ready message
-Write-Host "$(Get-Date -Format $timeFormat): Development ENTRYPOINT: ready!"
-
-& "C:\\service\\$($env:WORKER_EXECUTABLE_NAME_ENV)"

--- a/image/test/scripts/Watch-Directory.Tests.ps1
+++ b/image/test/scripts/Watch-Directory.Tests.ps1
@@ -50,7 +50,7 @@ Describe 'Watch-Directory.ps1' {
         $dst = New-Item -Path (Join-Path $TestDrive (Get-Random)) -ItemType 'Directory'
 
         $job = Start-Job -ScriptBlock { Start-Sleep -Milliseconds 500; New-Item -Path "$($args[0])\file.txt" } -ArgumentList $src
-        & $script -Path $src -Destination $dst -Timeout 1000 -Sleep 100
+        & $script -Path $src -Destination $dst -Timeout 2000 -Sleep 100
         $job | Wait-Job | Remove-Job
 
         "$($dst)\file.txt" | Should -Exist


### PR DESCRIPTION
Hi,

The current sync scripts will not work with the services like IndexWorker, AutomationEngine and ProcessingEngine, as these services place a lock on the DLL files, and these services will not automatically restart when a config has changed.

This change changes the Watch-Directory script as follows:
- The script now starts the executable if it is passed
- When a file change is detected and we are running as service (based on the Executable parameter), the service is stopped
- The file changes are then synced
- The service is started

This change changes the Development.ps1 entrypoint script  for the worker as follows
- The entry point no longer starts the service itself
- The entry point passes the path to the executable to the Watch-Directory script

The changes make it possible to do continous development on the services instead of having to recreate the image all the time. The following entry point can now be passed from the docker-compose file:
```
  xdbautomationworker:
    image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-xp0-xdbautomationworker:${VERSION:-latest}
    entrypoint: powershell -Command "& C:\tools\entrypoints\worker\Development.ps1 -WatchDirectoryParameters @{Path = 'c:\deploy\App_Data\jobs\continuous\AutomationEngine';Destination = 'c:\service'}"
```
The _c:\deploy\App_Data\jobs\continuous\AutomationEngine_ path in the above snippet is the path within the container to which my AutomationEngine files are deployed, and could of course be changed to something else or an environment variable.
