### PR TITLE
#533349: change configuration using specific version of the nanoserve…

### DIFF
--- a/image/build/azure-pipelines-ltsc2019.yml
+++ b/image/build/azure-pipelines-ltsc2019.yml
@@ -27,7 +27,7 @@ variables:
   sitecoreVersion: $(SITECORE_VERSION)
   revision: $[counter(format('sitecoreVersion{0}', variables['sitecoreVersion']), 100)]
   osName: 1809
-  baseImage: mcr.microsoft.com/windows/nanoserver:$(osName)
+  baseImage: mcr.microsoft.com/windows/nanoserver:10.0.17763.2803
   buildImage: mcr.microsoft.com/windows/servercore:$(TARGETOS_LTSC2019)
   buildNumber: $(Build.BuildID)
   azureContainerRegistry: $(ACR_ContainerRegistry)

--- a/image/build/azure-pipelines-ltsc2022.yml
+++ b/image/build/azure-pipelines-ltsc2022.yml
@@ -27,7 +27,7 @@ variables:
   sitecoreVersion: $(SITECORE_VERSION)
   revision: $[counter(format('sitecoreVersion{0}', variables['sitecoreVersion']), 100)]
   osName: $(TARGETOS_LTSC2022)
-  baseImage: mcr.microsoft.com/windows/nanoserver:$(osName)
+  baseImage: mcr.microsoft.com/windows/nanoserver:10.0.20348.643
   buildImage: mcr.microsoft.com/windows/servercore:$(osName)
   buildNumber: $(Build.BuildID)
   azureContainerRegistry: $(ACR_ContainerRegistry)


### PR DESCRIPTION
Change configuration using a specific version of the nanoserver image (ltsc2019, ltsc2022) such as the last version of the "mcr.microsoft.com/windows/nanoserver:1809" for the ltsc2019 and "mcr.microsoft.com/windows/nanoserver:ltsc2022" for the ltsc2022 has an issue (images based on the servercore instead of the nanoserver).
We decided to use the previous stable version for 1809 is "mcr.microsoft.com/windows/nanoserver:10.0.17763.2803" and for ltsc2022 is "mcr.microsoft.com/windows/nanoserver:10.0.20348.643".
Created bug to the Microsoft: _https://github.com/microsoft/Windows-Containers/issues/225_
