### PR TITLE
Get-EnvFileContent fix

### DIFF
--- a/powershell/src/Private/Get-EnvFileContent.ps1
+++ b/powershell/src/Private/Get-EnvFileContent.ps1
@@ -3,8 +3,7 @@ Set-StrictMode -Version Latest
 function Get-EnvFileContent {
     Param (
         [Parameter(Mandatory = $true)]
-        [ValidateScript( { Test-Path $_ -IsValid })]
-        [ValidateScript( { [System.IO.Path]::IsPathRooted($_) })]
+        [ValidateScript( { Test-Path $_ -IsValid })]        
         [string]
         $File
     )

--- a/powershell/test/Private/Get-EnvFileContent.Tests.ps1
+++ b/powershell/test/Private/Get-EnvFileContent.Tests.ps1
@@ -19,8 +19,28 @@
             { Get-EnvFileContent -File ".\file.txt" } | Should -Throw
         }
 
-        It 'reads content from file' {
+        It 'reads content from file the absolute path' {
             $envFile = Join-Path $TestDrive '.env'
+            $content = @(
+                'VAR1=VAL1',
+                'VAR2=VAL2',
+                'VAR3=VAL3'
+            )
+            Set-Content $envFile -Value $content
+
+            $compare = @{
+                VAR1 = 'VAL1'
+                VAR2 = 'VAL2'
+                VAR3 = 'VAL3'
+            }
+
+            $result = Get-EnvFileContent -File $envFile
+            $result.Count | Should -Be $compare.Keys.Count
+            $result.Get_Item('VAR1') | Should -Be $compare.Get_Item('VAR1')
+        }
+
+        It 'reads content from file using the relative path' {
+            $envFile = '.env'
             $content = @(
                 'VAR1=VAL1',
                 'VAR2=VAL2',

--- a/powershell/test/Public/Get-EnvFileVariable.Tests.ps1
+++ b/powershell/test/Public/Get-EnvFileVariable.Tests.ps1
@@ -1,15 +1,23 @@
 . $PSScriptRoot\..\TestRunner.ps1 {
     . $PSScriptRoot\..\TestUtils.ps1
 
-    Describe 'Get-EnvFileVariable' {
+    Describe 'Get-EnvFileVariable' {       
 
-        $envFile = Join-Path $TestDrive '.env'
+        BeforeEach {
+            Push-Location $TestDrive
+        }
+
+        AfterEach {
+            Pop-Location
+        }
+            
+        $envFile = '.env'
         $content = @(
             'VAR1=VAL1',
             'VAR2=VAL2',
             'VAR3=VAL3'
         )
-        Set-Content $envFile -Value $content
+        Set-Content "$TestDrive\$envFile" -Value $content
 
         It 'requires $Variable' {
             $result = Test-ParamIsMandatory -Command Get-EnvFileVariable -Parameter Variable
@@ -17,7 +25,7 @@
         }
 
         It 'throws if $Path is invalid' {
-            { Get-EnvFileVariable -Variable "foo" -Value "bar" -Path "$TestDrive\.baz" } | Should -Throw
+            { Get-EnvFileVariable -Variable "foo" -Value "bar" -Path "$.baz" } | Should -Throw
         }
 
         It 'throws if $Variable is $null or empty' {
@@ -29,9 +37,21 @@
             { Get-EnvFileVariable -Path $envFile -Variable 'VAR' } | Should -Throw
         }
 
-        It 'reads variable correctly' {
+        It 'reads variable correctly usiing default file path' {
+            $value = 'VAL2'
+            $result = Get-EnvFileVariable -Variable 'VAR2'
+            $result | Should -Be $value
+        }
+
+        It 'reads variable correctly usiing relative file path' {
             $value = 'VAL2'
             $result = Get-EnvFileVariable -Path $envFile -Variable 'VAR2'
+            $result | Should -Be $value
+        }
+
+        It 'reads variable correctly usiing absolute file path' {
+            $value = 'VAL2'
+            $result = Get-EnvFileVariable -Path "$TestDrive\$envFile" -Variable 'VAR2'
             $result | Should -Be $value
         }
     }


### PR DESCRIPTION
Fixes #38

Fixed Unit Tests identified bugs: Removed redundant validator on Get-EnvFileContent function's Path parameter
