### PR TITLE
Support setting / getting literals in environment variables

### DIFF
--- a/powershell/src/Public/Set-EnvFileVariable.ps1
+++ b/powershell/src/Public/Set-EnvFileVariable.ps1
@@ -51,10 +51,6 @@ function Set-EnvFileVariable
     if (!(Test-Path $Path)) {
         throw "The environment file $Path does not exist"
     }
-
-    # Escape any '$' to prevent being used as a regex substitution
-    $Value = $Value.Replace('$', '$$')
-
     
     if ($AsLiteral){
           # Escape any ' to avoid terminating the value unexpectedly
@@ -65,6 +61,8 @@ function Set-EnvFileVariable
 
     $lines = @(Get-Content $Path -Encoding UTF8 | ForEach-Object {
         if ($_ -imatch "^$Variable=.*") {
+            # Escape any '$' to prevent being used as a regex substitution
+            $Value = $Value.Replace('$', '$$')
             $_ -ireplace "^$Variable=.*", "$Variable=$Value"
             $found = $true
         }

--- a/powershell/src/Public/Set-EnvFileVariable.ps1
+++ b/powershell/src/Public/Set-EnvFileVariable.ps1
@@ -10,6 +10,8 @@ Set-StrictMode -Version Latest
     Specifies the variable name.
 .PARAMETER Value
     Specifies the variable value.
+.PARAMETER AsLiteral
+    Specifies whether the Value should be written as a literal (i.e wrapped in single quotes)
 .PARAMETER Path
     Specifies the Docker environment (.env) file path. Assumes .env file is in the current directory by default.
 .EXAMPLE
@@ -18,6 +20,8 @@ Set-StrictMode -Version Latest
     PS C:\> "value one" | Set-EnvFileVariable "VAR1"
 .EXAMPLE
     PS C:\> Set-EnvFileVariable -Variable VAR1 -Value "value one" -Path .\src\.env
+.EXAMPLE
+    PS C:\> Set-EnvFileVariable -Variable VAR1 -Value "literal $tring" -AsLiteral
 .INPUTS
     System.String. You can pipe in the Value parameter.
 .OUTPUTS
@@ -37,6 +41,9 @@ function Set-EnvFileVariable
         [string]
         $Value,
 
+        [switch]
+        $AsLiteral = $false,
+
         [string]
         $Path = ".\.env"
     )
@@ -48,6 +55,12 @@ function Set-EnvFileVariable
     # Escape any '$' to prevent being used as a regex substitution
     $Value = $Value.Replace('$', '$$')
 
+    
+    if ($AsLiteral){
+          # Escape any ' to avoid terminating the value unexpectedly
+        $Value = "'$($Value.Replace("'", "''"))'"
+    }
+    
     $found = $false
 
     $lines = @(Get-Content $Path -Encoding UTF8 | ForEach-Object {

--- a/powershell/test/Public/Get-EnvFileVariable.Tests.ps1
+++ b/powershell/test/Public/Get-EnvFileVariable.Tests.ps1
@@ -42,19 +42,19 @@
             { Get-EnvFileVariable -Path $envFile -Variable 'VAR' } | Should -Throw
         }
 
-        It 'reads variable correctly usiing default file path' {
+        It 'reads variable correctly using default file path' {
             $value = 'VAL2'
             $result = Get-EnvFileVariable -Variable 'VAR2'
             $result | Should -Be $value
         }
 
-        It 'reads variable correctly usiing relative file path' {
+        It 'reads variable correctly using relative file path' {
             $value = 'VAL2'
             $result = Get-EnvFileVariable -Path $envFile -Variable 'VAR2'
             $result | Should -Be $value
         }
 
-        It 'reads variable correctly usiing absolute file path' {
+        It 'reads variable correctly using absolute file path' {
             $value = 'VAL2'
             $result = Get-EnvFileVariable -Path "$TestDrive\$envFile" -Variable 'VAR2'
             $result | Should -Be $value

--- a/powershell/test/Public/Get-EnvFileVariable.Tests.ps1
+++ b/powershell/test/Public/Get-EnvFileVariable.Tests.ps1
@@ -15,7 +15,12 @@
         $content = @(
             'VAR1=VAL1',
             'VAR2=VAL2',
-            'VAR3=VAL3'
+            'VAR3=VAL3',
+            'VAR4=''VAL4$Literal''',
+            "VAR5=''VAL5''Escaped''",
+            "VAR6='VAL6''EscapedLiteral'",
+            "VAR7='VAL7"
+            "VAR8='''VAL8'"
         )
         Set-Content "$TestDrive\$envFile" -Value $content
 
@@ -52,6 +57,35 @@
         It 'reads variable correctly usiing absolute file path' {
             $value = 'VAL2'
             $result = Get-EnvFileVariable -Path "$TestDrive\$envFile" -Variable 'VAR2'
+            $result | Should -Be $value
+        }
+
+        It 'reads variable correctly using a literal value' {
+            $value = 'VAL4$Literal'
+            $result = Get-EnvFileVariable -Variable 'VAR4'
+            $result | Should -Be $value
+        }
+
+        It 'reads variable correctly using quotes in non-literal strings' {
+            $value = "''VAL5''Escaped''"
+            $result = Get-EnvFileVariable -Variable 'VAR5'
+            $result | Should -Be $value
+        }
+
+        It 'reads variable correctly using escaped quotes in literals' {
+            $value = "VAL6'EscapedLiteral"
+            $result = Get-EnvFileVariable -Variable 'VAR6'
+            $result | Should -Be $value
+        }
+        
+        It 'reads variable correctly using non-literal strings starting with quote' {
+            $value = "'VAL7"
+            $result = Get-EnvFileVariable -Variable 'VAR7'
+            $result | Should -Be $value
+        }
+        It 'reads variable correctly using literal strings starting with quote' {
+            $value = "'VAL8"
+            $result = Get-EnvFileVariable -Variable 'VAR8'
             $result | Should -Be $value
         }
     }

--- a/powershell/test/Public/Set-EnvFileVariable.Tests.ps1
+++ b/powershell/test/Public/Set-EnvFileVariable.Tests.ps1
@@ -118,6 +118,36 @@
             $envFile | Should -FileContentMatchExactly '^VAR2=two$'
         }
 
+        It 'sets variables with literal values when specified' {
+            Set-Content $envFile -Value @(
+                'VAR1=VAL1',
+                'VAR2=VAL2',
+                'VAR3=VAL3'
+            )
+            Set-EnvFileVariable -Path $envFile -Variable 'VAR2' -Value 'literal$tring' -AsLiteral
+            $envFile | Should -FileContentMatchExactly ([regex]::Escape('VAR2=''literal$tring'''))
+        }
+
+        It 'adds variable with literal values when specified' {
+            Set-Content $envFile -Value @(
+                'VAR1=VAL1',
+                'VAR2=VAL2',
+                'VAR3=VAL3'
+            )
+            Set-EnvFileVariable -Path $envFile -Variable 'VAR4' -Value 'literal$tring' -AsLiteral
+            $envFile | Should -FileContentMatchExactly  ([regex]::Escape('VAR4=''literal$tring'''))
+        }
+
+        It 'adds variable with literal values when specified' {
+            Set-Content $envFile -Value @(
+                'VAR1=VAL1',
+                'VAR2=VAL2',
+                'VAR3=VAL3'
+            )
+            Set-EnvFileVariable -Path $envFile -Variable 'VAR2' -Value "VAL2'Escaped" -AsLiteral
+            $envFile | Should -FileContentMatchExactly "VAR2='VAL2''Escaped'"
+        }
+
         It 'uses .\.env as default $Path' {
             Set-Content $envFile -Value "foo=bar"
 


### PR DESCRIPTION
Hi,
This PR adds support to allow developers to explicitly choose to set environment variables as a literal (ie. wrapped in single quotes).

E.G.  
`Set-EnvFileVariable -Variable 'VAR4' -Value 'literal$tring' -AsLiteral`

Would write the following to the .env
`VAR4='literal$tring'`

I believe this is an improvement due to:
- Improved DX giving developers the explicit choice of when to use literals when setting/getting env vars
- Allows for special characters in keys/secrets when setting/getting env vars that may have been generated in other systems, which in some cases may not be avoided
- Improves IDE syntax highlighting in .env files when there are special characters (special characters in long strings throw it off)
- Enhances support for all previous flags when using Get-SitecoreRandomString e.g. -DisallowSpecial, -DisallowDollar etc where used

Bonus: Also fixes a bug where the replacement of $ in Set-EnvFileVariable will result in different outcomes depending on if it was an existing variable (inserted via regex) vs a new variable (interpolated with the $'s doubled) in the .env file.