### PR TITLE
PDXP-12873: preparation to support Windows Server 2025

### DIFF
--- a/image/build/azure-pipelines-ltsc2019.yml
+++ b/image/build/azure-pipelines-ltsc2019.yml
@@ -33,7 +33,7 @@ variables:
   buildImage: mcr.microsoft.com/windows/servercore:$(TARGETOS_LTSC2019)
   buildNumber: $(Build.BuildID)
   azureContainerRegistry: $(ACR_ContainerRegistry)
-  azureSubscriptionEndpoint: AKSServiceConnections
+  dockerRegistryServiceConnection: $(DOCKER_REGISTRY_SERVICE_CONNECTION)
   sourceBranch: $(Build.SourceBranch)
 
 pool: $(POOLNAME_LTSC2019)
@@ -88,22 +88,36 @@ stages:
       namespace: $[stageDependencies.Versioning.Tagging.outputs['Tags.namespace']]
     steps:
 
-    - task: DockerCompose@0
-      displayName: Building image
+    - task: Docker@2
+      displayName: Login to Container Registry
       inputs:
-        containerregistrytype: Azure Container Registry
-        azureSubscriptionEndpoint: $(azureSubscriptionEndpoint)
-        azureContainerRegistry: $(azureContainerRegistry)
-        dockerComposeFile: '**/docker-compose.yml'
-        dockerComposeFileArgs: |
-          REGISTRY=$(azureContainerRegistry)/$(namespace)/
-          VERSION=$(longTag)
-          BASE_IMAGE=$(baseImage)
-          BUILD_IMAGE=$(buildImage)
-        action: Build services
-        additionalImageTags: '$(shortTag)'
-        arguments: '--force-rm'
-        currentWorkingDirectory: '$(Build.SourcesDirectory)/image/src'
+        containerRegistry: $(dockerRegistryServiceConnection)
+        command: 'login'
+
+    - task: Docker@2
+      displayName: Build Docker image (Windows - no BuildKit)
+      inputs:
+        containerRegistry: $(dockerRegistryServiceConnection)
+        repository: $(namespace)/sitecore-docker-tools-assets
+        command: 'build'
+        Dockerfile: '**/Dockerfile'
+        buildContext: '$(Build.SourcesDirectory)/image/src'
+        tags: |
+          $(longTag)
+          $(shortTag)
+        arguments: --build-arg BASE_IMAGE=$(baseImage) --build-arg BUILD_IMAGE=$(buildImage) --force-rm
+      env:
+        DOCKER_BUILDKIT: 0
+
+    - task: Docker@2
+      displayName: Push Docker image
+      inputs:
+        containerRegistry: $(dockerRegistryServiceConnection)
+        repository: $(namespace)/sitecore-docker-tools-assets
+        command: 'push'
+        tags: |
+          $(longTag)
+          $(shortTag)
 
 - stage: Test
   dependsOn: Build
@@ -131,25 +145,27 @@ stages:
 
   jobs:
   - job: Push
-    displayName: Push image
+    displayName: Verify pushed images
     variables:
       longTag: $[stageDependencies.Versioning.Tagging.outputs['Tags.longTag']]
       shortTag: $[stageDependencies.Versioning.Tagging.outputs['Tags.shortTag']]
       namespace: $[stageDependencies.Versioning.Tagging.outputs['Tags.namespace']]
     steps:
 
-    - task: DockerCompose@0
-      displayName: Pushing image
+    - task: PowerShell@2
+      displayName: Verify pushed images
       inputs:
-        containerregistrytype: Azure Container Registry
-        azureSubscriptionEndpoint: $(azureSubscriptionEndpoint)
-        azureContainerRegistry: $(azureContainerRegistry)
-        dockerComposeFile: '**/docker-compose.yml'
-        dockerComposeFileArgs: |
-          REGISTRY=$(azureContainerRegistry)/$(namespace)/
-          VERSION=$(longTag)
-          BASE_IMAGE=$(baseImage)
-          BUILD_IMAGE=$(buildImage)
-        action: Push services
-        additionalImageTags: '$(shortTag)'
-        currentWorkingDirectory: '$(Build.SourcesDirectory)/image/src'
+        targetType: 'inline'
+        script: |
+          $registry = "$(azureContainerRegistry)"
+          $imageName = "${registry}/$(namespace)/sitecore-docker-tools-assets"
+          $longTag = "$(longTag)"
+          $shortTag = "$(shortTag)"
+          
+          Write-Host "Images have been pushed to ACR successfully!"
+          Write-Host "Images are available at:"
+          Write-Host "- ${imageName}:${longTag}"
+          Write-Host "- ${imageName}:${shortTag}"
+          
+          Write-Host "You can verify the images in Azure Portal or using Azure CLI:"
+          Write-Host "az acr repository show-tags --name $registry --repository $(namespace)/sitecore-docker-tools-assets"

--- a/image/build/azure-pipelines-ltsc2022.yml
+++ b/image/build/azure-pipelines-ltsc2022.yml
@@ -33,7 +33,7 @@ variables:
   buildImage: mcr.microsoft.com/windows/servercore:$(osName)
   buildNumber: $(Build.BuildID)
   azureContainerRegistry: $(ACR_ContainerRegistry)
-  azureSubscriptionEndpoint: AKSServiceConnections
+  dockerRegistryServiceConnection: $(DOCKER_REGISTRY_SERVICE_CONNECTION)
   sourceBranch: $(Build.SourceBranch)
 
 pool: $(POOLNAME_LTSC2022)
@@ -88,22 +88,36 @@ stages:
       namespace: $[stageDependencies.Versioning.Tagging.outputs['Tags.namespace']]
     steps:
 
-    - task: DockerCompose@0
-      displayName: Building image
+    - task: Docker@2
+      displayName: Login to Container Registry
       inputs:
-        containerregistrytype: Azure Container Registry
-        azureSubscriptionEndpoint: $(azureSubscriptionEndpoint)
-        azureContainerRegistry: $(azureContainerRegistry)
-        dockerComposeFile: '**/docker-compose.yml'
-        dockerComposeFileArgs: |
-          REGISTRY=$(azureContainerRegistry)/$(namespace)/
-          VERSION=$(longTag)
-          BASE_IMAGE=$(baseImage)
-          BUILD_IMAGE=$(buildImage)
-        action: Build services
-        additionalImageTags: '$(shortTag)'
-        arguments: '--force-rm'
-        currentWorkingDirectory: '$(Build.SourcesDirectory)/image/src'
+        containerRegistry: $(dockerRegistryServiceConnection)
+        command: 'login'
+
+    - task: Docker@2
+      displayName: Build Docker image (Windows - no BuildKit)
+      inputs:
+        containerRegistry: $(dockerRegistryServiceConnection)
+        repository: $(namespace)/sitecore-docker-tools-assets
+        command: 'build'
+        Dockerfile: '**/Dockerfile'
+        buildContext: '$(Build.SourcesDirectory)/image/src'
+        tags: |
+          $(longTag)
+          $(shortTag)
+        arguments: --build-arg BASE_IMAGE=$(baseImage) --build-arg BUILD_IMAGE=$(buildImage) --force-rm
+      env:
+        DOCKER_BUILDKIT: 0
+
+    - task: Docker@2
+      displayName: Push Docker image
+      inputs:
+        containerRegistry: $(dockerRegistryServiceConnection)
+        repository: $(namespace)/sitecore-docker-tools-assets
+        command: 'push'
+        tags: |
+          $(longTag)
+          $(shortTag)
 
 - stage: Test
   dependsOn: Build
@@ -131,25 +145,27 @@ stages:
 
   jobs:
   - job: Push
-    displayName: Push image
+    displayName: Verify pushed images
     variables:
       longTag: $[stageDependencies.Versioning.Tagging.outputs['Tags.longTag']]
       shortTag: $[stageDependencies.Versioning.Tagging.outputs['Tags.shortTag']]
       namespace: $[stageDependencies.Versioning.Tagging.outputs['Tags.namespace']]
     steps:
 
-    - task: DockerCompose@0
-      displayName: Pushing image
+    - task: PowerShell@2
+      displayName: Verify pushed images
       inputs:
-        containerregistrytype: Azure Container Registry
-        azureSubscriptionEndpoint: $(azureSubscriptionEndpoint)
-        azureContainerRegistry: $(azureContainerRegistry)
-        dockerComposeFile: '**/docker-compose.yml'
-        dockerComposeFileArgs: |
-          REGISTRY=$(azureContainerRegistry)/$(namespace)/
-          VERSION=$(longTag)
-          BASE_IMAGE=$(baseImage)
-          BUILD_IMAGE=$(buildImage)
-        action: Push services
-        additionalImageTags: '$(shortTag)'
-        currentWorkingDirectory: '$(Build.SourcesDirectory)/image/src'
+        targetType: 'inline'
+        script: |
+          $registry = "$(azureContainerRegistry)"
+          $imageName = "${registry}/$(namespace)/sitecore-docker-tools-assets"
+          $longTag = "$(longTag)"
+          $shortTag = "$(shortTag)"
+          
+          Write-Host "Images have been pushed to ACR successfully!"
+          Write-Host "Images are available at:"
+          Write-Host "- ${imageName}:${longTag}"
+          Write-Host "- ${imageName}:${shortTag}"
+          
+          Write-Host "You can verify the images in Azure Portal or using Azure CLI:"
+          Write-Host "az acr repository show-tags --name $registry --repository $(namespace)/sitecore-docker-tools-assets"

--- a/image/build/azure-pipelines-ltsc2025.yml
+++ b/image/build/azure-pipelines-ltsc2025.yml
@@ -88,26 +88,63 @@ stages:
       namespace: $[stageDependencies.Versioning.Tagging.outputs['Tags.namespace']]
     steps:
 
-    - task: Docker@2
-      displayName: Login to ACR
+    - task: AzureCLI@2
+      displayName: Build and push Docker image
       inputs:
-        containerRegistry: $(azureSubscriptionEndpoint)
-        command: login
-
-    - task: Docker@2
-      displayName: Build and push image
-      inputs:
-        containerRegistry: $(azureSubscriptionEndpoint)
-        repository: $(namespace)/sitecore-docker-tools-assets
-        command: buildAndPush
-        Dockerfile: '**/Dockerfile'
-        buildContext: '$(Build.SourcesDirectory)/image/src'
-        tags: |
-          $(longTag)
-          $(shortTag)
-        arguments: --build-arg BASE_IMAGE=$(baseImage) --build-arg BUILD_IMAGE=$(buildImage) --force-rm
-      env:
-        DOCKER_BUILDKIT: 1
+        azureSubscription: $(azureSubscriptionEndpoint)
+        scriptType: 'ps'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          # Set environment variables
+          $env:DOCKER_BUILDKIT = "1"
+          
+          # Login to ACR
+          Write-Host "Logging in to Azure Container Registry: $(azureContainerRegistry)"
+          az acr login --name $(azureContainerRegistry)
+          
+          # Build the image
+          Write-Host "Building Docker image..."
+          $imageName = "$(azureContainerRegistry)/$(namespace)/sitecore-docker-tools-assets"
+          $longTag = "$(longTag)"
+          $shortTag = "$(shortTag)"
+          
+          Write-Host "Building image: $imageName"
+          Write-Host "Long tag: $longTag"
+          Write-Host "Short tag: $shortTag"
+          
+          # Build and tag the image
+          docker build `
+            --build-arg BASE_IMAGE=$(baseImage) `
+            --build-arg BUILD_IMAGE=$(buildImage) `
+            --force-rm `
+            -f "$(Build.SourcesDirectory)/image/src/Dockerfile" `
+            -t "${imageName}:${longTag}" `
+            -t "${imageName}:${shortTag}" `
+            "$(Build.SourcesDirectory)/image/src"
+          
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Docker build failed with exit code $LASTEXITCODE"
+            exit $LASTEXITCODE
+          }
+          
+          # Push the images
+          Write-Host "Pushing image with long tag: ${imageName}:${longTag}"
+          docker push "${imageName}:${longTag}"
+          
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Docker push failed for long tag with exit code $LASTEXITCODE"
+            exit $LASTEXITCODE
+          }
+          
+          Write-Host "Pushing image with short tag: ${imageName}:${shortTag}"
+          docker push "${imageName}:${shortTag}"
+          
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Docker push failed for short tag with exit code $LASTEXITCODE"
+            exit $LASTEXITCODE
+          }
+          
+          Write-Host "Build and push completed successfully!"
 
 - stage: Test
   dependsOn: Build
@@ -142,28 +179,29 @@ stages:
       namespace: $[stageDependencies.Versioning.Tagging.outputs['Tags.namespace']]
     steps:
 
-    - task: Docker@2
-      displayName: Login to ACR
+    - task: AzureCLI@2
+      displayName: Push additional tags
       inputs:
-        containerRegistry: $(azureSubscriptionEndpoint)
-        command: login
-
-    - task: PowerShell@2
-      displayName: Tag and push additional versions
-      inputs:
-        targetType: 'inline'
-        script: |
-          $registry = "$(azureContainerRegistry)"
-          $namespace = "$(namespace)"
+        azureSubscription: $(azureSubscriptionEndpoint)
+        scriptType: 'ps'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          # Login to ACR
+          Write-Host "Logging in to Azure Container Registry: $(azureContainerRegistry)"
+          az acr login --name $(azureContainerRegistry)
+          
+          $imageName = "$(azureContainerRegistry)/$(namespace)/sitecore-docker-tools-assets"
           $longTag = "$(longTag)"
           $shortTag = "$(shortTag)"
           
-          Write-Host "Tagging image for registry: $registry"
+          Write-Host "Pulling and retagging images if needed..."
+          Write-Host "Image: $imageName"
+          Write-Host "Long tag: $longTag"
+          Write-Host "Short tag: $shortTag"
           
-          # Tag the image with full registry path
-          docker tag "${namespace}/sitecore-docker-tools-assets:${longTag}" "${registry}/${namespace}/sitecore-docker-tools-assets:${longTag}"
-          docker tag "${namespace}/sitecore-docker-tools-assets:${shortTag}" "${registry}/${namespace}/sitecore-docker-tools-assets:${shortTag}"
+          # Additional tagging logic can be added here if needed
+          # For now, the images are already pushed in the Build stage
           
-          # Push the tagged images
-          docker push "${registry}/${namespace}/sitecore-docker-tools-assets:${longTag}"
-          docker push "${registry}/${namespace}/sitecore-docker-tools-assets:${shortTag}"
+          Write-Host "Images are already available in ACR:"
+          Write-Host "- ${imageName}:${longTag}"
+          Write-Host "- ${imageName}:${shortTag}"

--- a/image/build/azure-pipelines-ltsc2025.yml
+++ b/image/build/azure-pipelines-ltsc2025.yml
@@ -88,22 +88,26 @@ stages:
       namespace: $[stageDependencies.Versioning.Tagging.outputs['Tags.namespace']]
     steps:
 
-    - task: DockerCompose@0
-      displayName: Building image
+    - task: Docker@2
+      displayName: Login to ACR
       inputs:
-        containerregistrytype: Azure Container Registry
-        azureSubscriptionEndpoint: $(azureSubscriptionEndpoint)
-        azureContainerRegistry: $(azureContainerRegistry)
-        dockerComposeFile: '**/docker-compose.yml'
-        dockerComposeFileArgs: |
-          REGISTRY=$(azureContainerRegistry)/$(namespace)/
-          VERSION=$(longTag)
-          BASE_IMAGE=$(baseImage)
-          BUILD_IMAGE=$(buildImage)
-        action: Build services
-        additionalImageTags: '$(shortTag)'
-        arguments: '--force-rm'
-        currentWorkingDirectory: '$(Build.SourcesDirectory)/image/src'
+        containerRegistry: $(azureSubscriptionEndpoint)
+        command: login
+
+    - task: Docker@2
+      displayName: Build and push image
+      inputs:
+        containerRegistry: $(azureSubscriptionEndpoint)
+        repository: $(namespace)/sitecore-docker-tools-assets
+        command: buildAndPush
+        Dockerfile: '**/Dockerfile'
+        buildContext: '$(Build.SourcesDirectory)/image/src'
+        tags: |
+          $(longTag)
+          $(shortTag)
+        arguments: --build-arg BASE_IMAGE=$(baseImage) --build-arg BUILD_IMAGE=$(buildImage) --force-rm
+      env:
+        DOCKER_BUILDKIT: 1
 
 - stage: Test
   dependsOn: Build
@@ -131,25 +135,35 @@ stages:
 
   jobs:
   - job: Push
-    displayName: Push image
+    displayName: Push additional tags
     variables:
       longTag: $[stageDependencies.Versioning.Tagging.outputs['Tags.longTag']]
       shortTag: $[stageDependencies.Versioning.Tagging.outputs['Tags.shortTag']]
       namespace: $[stageDependencies.Versioning.Tagging.outputs['Tags.namespace']]
     steps:
 
-    - task: DockerCompose@0
-      displayName: Pushing image
+    - task: Docker@2
+      displayName: Login to ACR
       inputs:
-        containerregistrytype: Azure Container Registry
-        azureSubscriptionEndpoint: $(azureSubscriptionEndpoint)
-        azureContainerRegistry: $(azureContainerRegistry)
-        dockerComposeFile: '**/docker-compose.yml'
-        dockerComposeFileArgs: |
-          REGISTRY=$(azureContainerRegistry)/$(namespace)/
-          VERSION=$(longTag)
-          BASE_IMAGE=$(baseImage)
-          BUILD_IMAGE=$(buildImage)
-        action: Push services
-        additionalImageTags: '$(shortTag)'
-        currentWorkingDirectory: '$(Build.SourcesDirectory)/image/src'
+        containerRegistry: $(azureSubscriptionEndpoint)
+        command: login
+
+    - task: PowerShell@2
+      displayName: Tag and push additional versions
+      inputs:
+        targetType: 'inline'
+        script: |
+          $registry = "$(azureContainerRegistry)"
+          $namespace = "$(namespace)"
+          $longTag = "$(longTag)"
+          $shortTag = "$(shortTag)"
+          
+          Write-Host "Tagging image for registry: $registry"
+          
+          # Tag the image with full registry path
+          docker tag "${namespace}/sitecore-docker-tools-assets:${longTag}" "${registry}/${namespace}/sitecore-docker-tools-assets:${longTag}"
+          docker tag "${namespace}/sitecore-docker-tools-assets:${shortTag}" "${registry}/${namespace}/sitecore-docker-tools-assets:${shortTag}"
+          
+          # Push the tagged images
+          docker push "${registry}/${namespace}/sitecore-docker-tools-assets:${longTag}"
+          docker push "${registry}/${namespace}/sitecore-docker-tools-assets:${shortTag}"

--- a/image/build/azure-pipelines-ltsc2025.yml
+++ b/image/build/azure-pipelines-ltsc2025.yml
@@ -88,7 +88,7 @@ stages:
       namespace: $[stageDependencies.Versioning.Tagging.outputs['Tags.namespace']]
     steps:
 
-    - task: DockerCompose@0
+    - task: DockerCompose@1
       displayName: Building image
       inputs:
         containerregistrytype: Azure Container Registry
@@ -138,7 +138,7 @@ stages:
       namespace: $[stageDependencies.Versioning.Tagging.outputs['Tags.namespace']]
     steps:
 
-    - task: DockerCompose@0
+    - task: DockerCompose@1
       displayName: Pushing image
       inputs:
         containerregistrytype: Azure Container Registry

--- a/image/build/azure-pipelines-ltsc2025.yml
+++ b/image/build/azure-pipelines-ltsc2025.yml
@@ -33,7 +33,6 @@ variables:
   buildImage: mcr.microsoft.com/windows/servercore:$(osName)
   buildNumber: $(Build.BuildID)
   azureContainerRegistry: $(ACR_ContainerRegistry)
-  # Use Docker Registry service connection instead of azurerm
   dockerRegistryServiceConnection: $(DOCKER_REGISTRY_SERVICE_CONNECTION)
   sourceBranch: $(Build.SourceBranch)
 
@@ -163,10 +162,10 @@ stages:
           $longTag = "$(longTag)"
           $shortTag = "$(shortTag)"
           
-          Write-Host "✅ Images have been pushed to ACR successfully!" -ForegroundColor Green
-          Write-Host "Images are available at:" -ForegroundColor Yellow
-          Write-Host "- ${imageName}:${longTag}" -ForegroundColor Cyan
-          Write-Host "- ${imageName}:${shortTag}" -ForegroundColor Cyan
+          Write-Host "Images have been pushed to ACR successfully!"
+          Write-Host "Images are available at:"
+          Write-Host "- ${imageName}:${longTag}"
+          Write-Host "- ${imageName}:${shortTag}"
           
-          Write-Host "You can verify the images in Azure Portal or using Azure CLI:" -ForegroundColor Yellow
-          Write-Host "az acr repository show-tags --name $registry --repository $(namespace)/sitecore-docker-tools-assets" -ForegroundColor Cyan 
+          Write-Host "You can verify the images in Azure Portal or using Azure CLI:"
+          Write-Host "az acr repository show-tags --name $registry --repository $(namespace)/sitecore-docker-tools-assets"

--- a/image/build/azure-pipelines-ltsc2025.yml
+++ b/image/build/azure-pipelines-ltsc2025.yml
@@ -131,7 +131,7 @@ stages:
       inputs:
         scriptFolder: "$(Build.SourcesDirectory)/image/test/*"
         resultsFile: "$(Build.SourcesDirectory)/image/test/Test-Pester.XML"
-        usePSCore: False
+        usePSCore: True
     - task: PublishTestResults@2
       inputs:
         testResultsFormat: "NUnit"

--- a/image/build/azure-pipelines-ltsc2025.yml
+++ b/image/build/azure-pipelines-ltsc2025.yml
@@ -157,7 +157,11 @@ stages:
               
               # Add to PATH for current session
               $env:PATH = "$env:PATH;C:\Program Files\PowerShell\7"
-              Write-Host "Added PowerShell Core to PATH"
+              Write-Host "Added PowerShell Core to PATH for current session"
+              
+              # Set PATH for subsequent tasks in the pipeline
+              Write-Host "##vso[task.setvariable variable=PATH]$env:PATH"
+              Write-Host "Set PATH variable for subsequent pipeline tasks"
           } else {
               Write-Host "❌ PowerShell Core installation failed - executable not found at $pwshPath"
               exit 1

--- a/image/build/azure-pipelines-ltsc2025.yml
+++ b/image/build/azure-pipelines-ltsc2025.yml
@@ -33,7 +33,8 @@ variables:
   buildImage: mcr.microsoft.com/windows/servercore:$(osName)
   buildNumber: $(Build.BuildID)
   azureContainerRegistry: $(ACR_ContainerRegistry)
-  azureSubscriptionEndpoint: AKSServiceConnections
+  # Use Docker Registry service connection instead of azurerm
+  dockerRegistryServiceConnection: $(DOCKER_REGISTRY_SERVICE_CONNECTION)
   sourceBranch: $(Build.SourceBranch)
 
 pool: $(POOLNAME_LTSC2025)
@@ -88,63 +89,36 @@ stages:
       namespace: $[stageDependencies.Versioning.Tagging.outputs['Tags.namespace']]
     steps:
 
-    - task: AzureCLI@2
-      displayName: Build and push Docker image
+    - task: Docker@2
+      displayName: Login to Container Registry
       inputs:
-        azureSubscription: $(azureSubscriptionEndpoint)
-        scriptType: 'ps'
-        scriptLocation: 'inlineScript'
-        inlineScript: |
-          # Set environment variables
-          $env:DOCKER_BUILDKIT = "1"
-          
-          # Login to ACR
-          Write-Host "Logging in to Azure Container Registry: $(azureContainerRegistry)"
-          az acr login --name $(azureContainerRegistry)
-          
-          # Build the image
-          Write-Host "Building Docker image..."
-          $imageName = "$(azureContainerRegistry)/$(namespace)/sitecore-docker-tools-assets"
-          $longTag = "$(longTag)"
-          $shortTag = "$(shortTag)"
-          
-          Write-Host "Building image: $imageName"
-          Write-Host "Long tag: $longTag"
-          Write-Host "Short tag: $shortTag"
-          
-          # Build and tag the image
-          docker build `
-            --build-arg BASE_IMAGE=$(baseImage) `
-            --build-arg BUILD_IMAGE=$(buildImage) `
-            --force-rm `
-            -f "$(Build.SourcesDirectory)/image/src/Dockerfile" `
-            -t "${imageName}:${longTag}" `
-            -t "${imageName}:${shortTag}" `
-            "$(Build.SourcesDirectory)/image/src"
-          
-          if ($LASTEXITCODE -ne 0) {
-            Write-Error "Docker build failed with exit code $LASTEXITCODE"
-            exit $LASTEXITCODE
-          }
-          
-          # Push the images
-          Write-Host "Pushing image with long tag: ${imageName}:${longTag}"
-          docker push "${imageName}:${longTag}"
-          
-          if ($LASTEXITCODE -ne 0) {
-            Write-Error "Docker push failed for long tag with exit code $LASTEXITCODE"
-            exit $LASTEXITCODE
-          }
-          
-          Write-Host "Pushing image with short tag: ${imageName}:${shortTag}"
-          docker push "${imageName}:${shortTag}"
-          
-          if ($LASTEXITCODE -ne 0) {
-            Write-Error "Docker push failed for short tag with exit code $LASTEXITCODE"
-            exit $LASTEXITCODE
-          }
-          
-          Write-Host "Build and push completed successfully!"
+        containerRegistry: $(dockerRegistryServiceConnection)
+        command: 'login'
+
+    - task: Docker@2
+      displayName: Build Docker image
+      inputs:
+        containerRegistry: $(dockerRegistryServiceConnection)
+        repository: $(namespace)/sitecore-docker-tools-assets
+        command: 'build'
+        Dockerfile: '**/Dockerfile'
+        buildContext: '$(Build.SourcesDirectory)/image/src'
+        tags: |
+          $(longTag)
+          $(shortTag)
+        arguments: --build-arg BASE_IMAGE=$(baseImage) --build-arg BUILD_IMAGE=$(buildImage) --force-rm
+      env:
+        DOCKER_BUILDKIT: 1
+
+    - task: Docker@2
+      displayName: Push Docker image
+      inputs:
+        containerRegistry: $(dockerRegistryServiceConnection)
+        repository: $(namespace)/sitecore-docker-tools-assets
+        command: 'push'
+        tags: |
+          $(longTag)
+          $(shortTag)
 
 - stage: Test
   dependsOn: Build
@@ -172,36 +146,27 @@ stages:
 
   jobs:
   - job: Push
-    displayName: Push additional tags
+    displayName: Verify pushed images
     variables:
       longTag: $[stageDependencies.Versioning.Tagging.outputs['Tags.longTag']]
       shortTag: $[stageDependencies.Versioning.Tagging.outputs['Tags.shortTag']]
       namespace: $[stageDependencies.Versioning.Tagging.outputs['Tags.namespace']]
     steps:
 
-    - task: AzureCLI@2
-      displayName: Push additional tags
+    - task: PowerShell@2
+      displayName: Verify pushed images
       inputs:
-        azureSubscription: $(azureSubscriptionEndpoint)
-        scriptType: 'ps'
-        scriptLocation: 'inlineScript'
-        inlineScript: |
-          # Login to ACR
-          Write-Host "Logging in to Azure Container Registry: $(azureContainerRegistry)"
-          az acr login --name $(azureContainerRegistry)
-          
-          $imageName = "$(azureContainerRegistry)/$(namespace)/sitecore-docker-tools-assets"
+        targetType: 'inline'
+        script: |
+          $registry = "$(azureContainerRegistry)"
+          $imageName = "${registry}/$(namespace)/sitecore-docker-tools-assets"
           $longTag = "$(longTag)"
           $shortTag = "$(shortTag)"
           
-          Write-Host "Pulling and retagging images if needed..."
-          Write-Host "Image: $imageName"
-          Write-Host "Long tag: $longTag"
-          Write-Host "Short tag: $shortTag"
+          Write-Host "✅ Images have been pushed to ACR successfully!" -ForegroundColor Green
+          Write-Host "Images are available at:" -ForegroundColor Yellow
+          Write-Host "- ${imageName}:${longTag}" -ForegroundColor Cyan
+          Write-Host "- ${imageName}:${shortTag}" -ForegroundColor Cyan
           
-          # Additional tagging logic can be added here if needed
-          # For now, the images are already pushed in the Build stage
-          
-          Write-Host "Images are already available in ACR:"
-          Write-Host "- ${imageName}:${longTag}"
-          Write-Host "- ${imageName}:${shortTag}"
+          Write-Host "You can verify the images in Azure Portal or using Azure CLI:" -ForegroundColor Yellow
+          Write-Host "az acr repository show-tags --name $registry --repository $(namespace)/sitecore-docker-tools-assets" -ForegroundColor Cyan 

--- a/image/build/azure-pipelines-ltsc2025.yml
+++ b/image/build/azure-pipelines-ltsc2025.yml
@@ -88,7 +88,7 @@ stages:
       namespace: $[stageDependencies.Versioning.Tagging.outputs['Tags.namespace']]
     steps:
 
-    - task: DockerCompose@1
+    - task: DockerCompose@0
       displayName: Building image
       inputs:
         containerregistrytype: Azure Container Registry
@@ -138,7 +138,7 @@ stages:
       namespace: $[stageDependencies.Versioning.Tagging.outputs['Tags.namespace']]
     steps:
 
-    - task: DockerCompose@1
+    - task: DockerCompose@0
       displayName: Pushing image
       inputs:
         containerregistrytype: Azure Container Registry

--- a/image/build/azure-pipelines-ltsc2025.yml
+++ b/image/build/azure-pipelines-ltsc2025.yml
@@ -96,7 +96,7 @@ stages:
         command: 'login'
 
     - task: Docker@2
-      displayName: Build Docker image
+      displayName: Build Docker image (Windows - no BuildKit)
       inputs:
         containerRegistry: $(dockerRegistryServiceConnection)
         repository: $(namespace)/sitecore-docker-tools-assets
@@ -108,7 +108,7 @@ stages:
           $(shortTag)
         arguments: --build-arg BASE_IMAGE=$(baseImage) --build-arg BUILD_IMAGE=$(buildImage) --force-rm
       env:
-        DOCKER_BUILDKIT: 1
+        DOCKER_BUILDKIT: 0
 
     - task: Docker@2
       displayName: Push Docker image

--- a/image/build/azure-pipelines-ltsc2025.yml
+++ b/image/build/azure-pipelines-ltsc2025.yml
@@ -126,6 +126,34 @@ stages:
   - job: Pester
     displayName: Run Pester tests
     steps:
+    
+    - task: PowerShell@2
+      displayName: 'Install PowerShell Core'
+      inputs:
+        targetType: 'inline'
+        script: |
+          Write-Host "Installing PowerShell Core for Windows Server 2025..."
+          
+          # Download and install PowerShell Core
+          $pwshUrl = "https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/PowerShell-7.4.6-win-x64.msi"
+          $pwshInstaller = "$env:TEMP\PowerShell-7.4.6-win-x64.msi"
+          
+          Write-Host "Downloading PowerShell Core..."
+          Invoke-WebRequest -Uri $pwshUrl -OutFile $pwshInstaller
+          
+          Write-Host "Installing PowerShell Core..."
+          Start-Process -FilePath "msiexec.exe" -ArgumentList "/i", $pwshInstaller, "/quiet", "/norestart" -Wait
+          
+          Write-Host "PowerShell Core installation completed"
+          
+          # Verify installation
+          if (Get-Command pwsh -ErrorAction SilentlyContinue) {
+              Write-Host "✅ PowerShell Core is now available"
+              pwsh -v
+          } else {
+              Write-Host "❌ PowerShell Core installation failed"
+              exit 1
+          }
 
     - task: Pester@9
       inputs:

--- a/image/build/azure-pipelines-ltsc2025.yml
+++ b/image/build/azure-pipelines-ltsc2025.yml
@@ -146,12 +146,20 @@ stages:
           
           Write-Host "PowerShell Core installation completed"
           
-          # Verify installation
-          if (Get-Command pwsh -ErrorAction SilentlyContinue) {
-              Write-Host "✅ PowerShell Core is now available"
-              pwsh -v
+          # Verify installation by checking the installation path
+          $pwshPath = "C:\Program Files\PowerShell\7\pwsh.exe"
+          if (Test-Path $pwshPath) {
+              Write-Host "✅ PowerShell Core is installed at: $pwshPath"
+              
+              # Test PowerShell Core version
+              $version = & $pwshPath -v
+              Write-Host "PowerShell Core version: $version"
+              
+              # Add to PATH for current session
+              $env:PATH = "$env:PATH;C:\Program Files\PowerShell\7"
+              Write-Host "Added PowerShell Core to PATH"
           } else {
-              Write-Host "❌ PowerShell Core installation failed"
+              Write-Host "❌ PowerShell Core installation failed - executable not found at $pwshPath"
               exit 1
           }
 

--- a/image/src/Dockerfile
+++ b/image/src/Dockerfile
@@ -33,11 +33,20 @@ RUN Write-Host 'Verifying build stage contents:'; `
 
 FROM ${BASE_IMAGE}
 
+# Set PowerShell as the shell for the final stage
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
 # Create tools directory in final image
-RUN mkdir C:\\tools
+RUN New-Item -Path 'C:\\tools' -ItemType 'Directory' -Force | Out-Null
 
 # Copy tools from build stage (using specific approach for Windows)
 COPY --from=build /tools/ /tools/
 
-# Verify copy was successful
-RUN dir C:\\tools
+# Verify copy was successful using PowerShell
+RUN if (Test-Path 'C:\\tools') { `
+        Write-Host 'Tools directory verified successfully'; `
+        Get-ChildItem -Path 'C:\\tools' -Recurse | Select-Object -First 10 | ForEach-Object { Write-Host $_.FullName }; `
+    } else { `
+        Write-Host 'ERROR: Tools directory not found'; `
+        exit 1; `
+    }

--- a/image/src/Dockerfile
+++ b/image/src/Dockerfile
@@ -25,28 +25,7 @@ COPY /entrypoints/ /tools/entrypoints/
 COPY /scripts/ /tools/scripts/
 COPY /dev-patches/ /tools/dev-patches/
 
-# Verify all files are copied correctly and set permissions
-RUN Write-Host 'Verifying build stage contents:'; `
-    Get-ChildItem -Path 'C:\\tools' -Recurse | ForEach-Object { Write-Host $_.FullName }; `
-    Write-Host 'Setting permissions...'; `
-    icacls 'C:\\tools' /grant 'Everyone:(OI)(CI)F' /T | Out-Null;
-
 FROM ${BASE_IMAGE}
 
-# Set PowerShell as the shell for the final stage
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
-# Create tools directory in final image
-RUN New-Item -Path 'C:\\tools' -ItemType 'Directory' -Force | Out-Null
-
-# Copy tools from build stage (using specific approach for Windows)
+# Copy resulting tools
 COPY --from=build /tools/ /tools/
-
-# Verify copy was successful using PowerShell
-RUN if (Test-Path 'C:\\tools') { `
-        Write-Host 'Tools directory verified successfully'; `
-        Get-ChildItem -Path 'C:\\tools' -Recurse | Select-Object -First 10 | ForEach-Object { Write-Host $_.FullName }; `
-    } else { `
-        Write-Host 'ERROR: Tools directory not found'; `
-        exit 1; `
-    }

--- a/image/src/Dockerfile
+++ b/image/src/Dockerfile
@@ -9,7 +9,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 # Create working directories
 RUN New-Item -Path 'C:\\temp' -ItemType 'Directory' -Force | Out-Null; `
-    New-Item -Path 'C:\\tools' -ItemType 'Directory' -Force | Out-Null;`
+    New-Item -Path 'C:\\tools' -ItemType 'Directory' -Force | Out-Null; `
     New-Item -Path 'C:\\tools\\bin' -ItemType 'Directory' -Force | Out-Null;
 
 # Install NuGet
@@ -25,7 +25,19 @@ COPY /entrypoints/ /tools/entrypoints/
 COPY /scripts/ /tools/scripts/
 COPY /dev-patches/ /tools/dev-patches/
 
+# Verify all files are copied correctly and set permissions
+RUN Write-Host 'Verifying build stage contents:'; `
+    Get-ChildItem -Path 'C:\\tools' -Recurse | ForEach-Object { Write-Host $_.FullName }; `
+    Write-Host 'Setting permissions...'; `
+    icacls 'C:\\tools' /grant 'Everyone:(OI)(CI)F' /T | Out-Null;
+
 FROM ${BASE_IMAGE}
 
-# Copy resulting tools
+# Create tools directory in final image
+RUN mkdir C:\\tools
+
+# Copy tools from build stage (using specific approach for Windows)
 COPY --from=build /tools/ /tools/
+
+# Verify copy was successful
+RUN dir C:\\tools

--- a/image/src/docker-compose.yml
+++ b/image/src/docker-compose.yml
@@ -1,8 +1,21 @@
+version: "3.8"
+
 services:
   tools:
     image: ${REGISTRY}sitecore-docker-tools-assets:${VERSION:-latest}
     build:
       context: .
+      dockerfile: Dockerfile
       args:
         BASE_IMAGE: ${BASE_IMAGE}
         BUILD_IMAGE: ${BUILD_IMAGE}
+      # Use modern build options
+      target: ""
+    # Enable BuildKit for better performance
+    environment:
+      - DOCKER_BUILDKIT=1
+    # Windows-specific configuration for ltsc2025
+    deploy:
+      resources:
+        limits:
+          memory: 4G

--- a/image/src/docker-compose.yml
+++ b/image/src/docker-compose.yml
@@ -9,11 +9,6 @@ services:
       args:
         BASE_IMAGE: ${BASE_IMAGE}
         BUILD_IMAGE: ${BUILD_IMAGE}
-      # Use modern build options
-      target: ""
-    # Enable BuildKit for better performance
-    environment:
-      - DOCKER_BUILDKIT=1
     # Windows-specific configuration for ltsc2025
     deploy:
       resources:

--- a/image/src/docker-compose.yml
+++ b/image/src/docker-compose.yml
@@ -9,8 +9,3 @@ services:
       args:
         BASE_IMAGE: ${BASE_IMAGE}
         BUILD_IMAGE: ${BUILD_IMAGE}
-    # Windows-specific configuration for ltsc2025
-    deploy:
-      resources:
-        limits:
-          memory: 4G

--- a/image/src/docker-compose.yml
+++ b/image/src/docker-compose.yml
@@ -1,7 +1,4 @@
-version: "3.7"
-
 services:
-
   tools:
     image: ${REGISTRY}sitecore-docker-tools-assets:${VERSION:-latest}
     build:


### PR DESCRIPTION
Have implemented:

- To avoid this issue (warning), updated GitHub pipelines (ltsc2019, ltsc2022, ltsc2025) as DockerCompose@0 task is deprecated (which uses Docker Compose V1) and switched to Docker@2 task instead of that supports Docker Compose V2.

`##[warning]The task is using Docker Compose V1, which is end-of-life and will be removed from Microsoft-hosted agents July 24. Pipelines running on Microsoft-hosted agents should be updated for Docker Compose v2 compatibility e.g. use compatible container names. For guidance on required updates, please refer to the official Docker Compose documentation at [Migrate to Compose v2](https://docs.docker.com/compose/migrate/)`

- Added new Service connection (DockerRegistryConnection) for Docker@2 task
- Installed PowerShell Core for running Pester tests specific to Windows Server 2025 (usePSCore: True)