### PR TITLE
Fix SQL Server authentication cert

### DIFF
--- a/powershell/src/Public/Create-SqlServerCertificate.ps1
+++ b/powershell/src/Public/Create-SqlServerCertificate.ps1
@@ -41,11 +41,11 @@ function Create-SqlServerCertificate{
 
         [Parameter()]
         [System.DateTimeOffset]
-        $NotBefore = [System.DateTimeOffset]::UtcNow,
+        $NotBefore = [System.DateTimeOffset]::Now,
 
         [Parameter()]
         [System.DateTimeOffset]
-        $NotAfter = [System.DateTimeOffset]::UtcNow.AddDays(3285)
+        $NotAfter = [System.DateTimeOffset]::Now.AddDays(3285)
     )
 
     Write-Information -MessageData "Creating a certificate for SqlServer with '$($SignerCertificate.Thumbprint)' signer." -InformationAction Continue

--- a/powershell/test/Public/Create-SqlServerCertificate.Tests.ps1
+++ b/powershell/test/Public/Create-SqlServerCertificate.Tests.ps1
@@ -59,5 +59,46 @@
                 $certificate.Issuer | Should -Be $signerCert.Subject
             }
         }
+                
+        Context 'When creating a self-signed certificate with DEFAULT validity period' {
+            It 'creates a certificate with the correct start and end dates' {
+                # Arrange
+                $commonName = 'test.sql.server'
+                $dnsName = 'test.sql.server'
+
+                # Act
+                $certificate = Create-SqlServerCertificate -CommonName $commonName -DnsName $dnsName -SignerCertificate $signerCert
+
+                # Assert
+                $certificate | Should -Not -BeNullOrEmpty
+                
+                # Check default validity period
+                $now = [System.DateTimeOffset]::Now
+                
+                $certificate.NotBefore | Should -BeGreaterThan ($now.DateTime.AddSeconds(-5))
+                $certificate.NotBefore | Should -BeLessThan ($now.DateTime.AddSeconds(5))
+                
+                $certificate.NotAfter | Should -BeGreaterThan ($now.AddDays(3285).DateTime.AddSeconds(-5))
+                $certificate.NotAfter | Should -BeLessThan ($now.AddDays(3285).DateTime.AddSeconds(5))
+            }
+        }
+
+        Context 'When creating a self-signed certificate with CUSTOM validity period' {
+            It 'creates a certificate with the correct start and end dates' {
+                # Arrange
+                $commonName = 'test.sql.server'
+                $dnsName = 'test.sql.server'
+                $notBefore = [System.DateTimeOffset]::UtcNow.AddDays(-1)
+                $notAfter = [System.DateTimeOffset]::UtcNow.AddDays(365)
+
+                # Act
+                $certificate = Create-SqlServerCertificate -CommonName $commonName -DnsName $dnsName -SignerCertificate $signerCert -NotBefore $notBefore -NotAfter $notAfter
+
+                # Assert
+                $certificate | Should -Not -BeNullOrEmpty
+                $certificate.NotBefore | Should -BeGreaterThan ($notBefore.DateTime.AddSeconds(-1))
+                $certificate.NotAfter | Should -BeLessThan ($notAfter.DateTime.AddSeconds(1))
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the newly generated SQL Server authentication cert, by defaulting a System timestamp instead of a UTC timestamp. This cert will then be active at creation time, so Sitecore login process won't have issues due to invalid certs.

Also included are some Unit tests to verify the SQL Server certs have valid start & end dates.

This fixes this issue: #60 